### PR TITLE
Update to use new GA BDS URL

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -129,7 +129,7 @@ else
     else
         curl --no-progress-meter -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o /minecraft/downloads/version.html https://www.minecraft.net/en-us/download/server/bedrock
     fi
-    LatestURL=$(grep -o 'https://minecraft.azureedge.net/bin-linux/[^"]*' downloads/version.html)
+    LatestURL=$(grep -o 'https://www.minecraft.net/bedrockdedicatedserver/bin-linux/[^"]*' downloads/version.html)
 
     LatestFile=$(echo "$LatestURL" | sed 's#.*/##')
 
@@ -149,7 +149,7 @@ else
     elif [ ! -z "$PinFile" ]; then
         echo "Installing $PinFile"
         DownloadFile=$PinFile
-        DownloadURL="https://minecraft.azureedge.net/bin-linux/$PinFile"
+        DownloadURL="https://www.minecraft.net/bedrockdedicatedserver/bin-linux/$PinFile"
 
         # Download version of Minecraft Bedrock dedicated server if it's not already local
         if [ ! -f "downloads/$DownloadFile" ]; then


### PR DESCRIPTION
The current script no longer updates Minecraft BDS instances because the URL has been changed to differentiate between GA and preview versions of BDS. This PR updates the URLs to the new GA equivalents.