### PR TITLE
New URL to locate server version and server download URL

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -125,11 +125,11 @@ if [ "$?" != 0 ]; then
 else
     # Download server index.html to check latest version
     if [ -z "$QuietCurl" ]; then
-        curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o /minecraft/downloads/version.html https://www.minecraft.net/en-us/download/server/bedrock
+        curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o /minecraft/downloads/version.json https://net-secondary.web.minecraft-services.net/api/v1.0/download/links
     else
-        curl --no-progress-meter -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o /minecraft/downloads/version.html https://www.minecraft.net/en-us/download/server/bedrock
+        curl --no-progress-meter -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o /minecraft/downloads/version.json https://net-secondary.web.minecraft-services.net/api/v1.0/download/links
     fi
-    LatestURL=$(grep -o 'https://www.minecraft.net/bedrockdedicatedserver/bin-linux/[^"]*' downloads/version.html)
+    LatestURL=$(grep -o 'https://www.minecraft.net/bedrockdedicatedserver/bin-linux/[^"]*' downloads/version.json)
 
     LatestFile=$(echo "$LatestURL" | sed 's#.*/##')
 


### PR DESCRIPTION
As per [#21](https://github.com/TheRemote/Legendary-Bedrock-Container/issues/21)
Incorporated same URL as pull request #156 for TheRemote/MinecraftBedrockServer. With the addition of changing file extention of version.html to version.json to reflect the format of the result.
Tested with local build of image using amd64.Dockerfile.